### PR TITLE
fix to use 'plenary.path' instead of 'telescope.path'

### DIFF
--- a/lua/telescope/_extensions/memo_builtin.lua
+++ b/lua/telescope/_extensions/memo_builtin.lua
@@ -3,7 +3,7 @@ local entry_display = require'telescope.pickers.entry_display'
 local files = require'telescope.builtin.files'
 local finders = require'telescope.finders'
 local from_entry = require'telescope.from_entry'
-local path = require'telescope.path'
+local Path = require'plenary.path'
 local pickers = require'telescope.pickers'
 local previewers = require'telescope.previewers'
 local utils = require'telescope.utils'
@@ -38,7 +38,7 @@ local function gen_from_memo(opts)
       display = make_display,
       filename = fields[1],
       ordinal = fields[1],
-      path = opts.memo_dir..path.separator..fields[1],
+      path = opts.memo_dir..Path.path.sep..fields[1],
       title = fields[2],
       value = fields[1],
     }


### PR DESCRIPTION
Hello, thank you for your good plugin.
I use everyday this plugin.

Today I notice the following error.

```
[telescope] [ERROR 20:53:54] ....cache/dein/.cache/init.vim/.dein/lua/telescope/path.lua:92: telescope.path is deprecated. please use plenary.path instead
```

This message caused by this commit.
nvim-telescope/telescope.nvim@df579ba

So I try to update :)