### PR TITLE
expand environment variables in memo config dir

### DIFF
--- a/lua/telescope/_extensions/memo_builtin.lua
+++ b/lua/telescope/_extensions/memo_builtin.lua
@@ -50,7 +50,7 @@ local function detect_memo_dir(memo_bin)
   for _, line in ipairs(lines) do
     local dir = line:match'memodir%s*=%s*"(.*)"'
     if dir then
-      return dir
+      return Path.expand(Path.new(dir))
     end
   end
   echo('cannot detect memodir', 'ErrorMsg')

--- a/lua/telescope/_extensions/memo_builtin.lua
+++ b/lua/telescope/_extensions/memo_builtin.lua
@@ -50,7 +50,7 @@ local function detect_memo_dir(memo_bin)
   for _, line in ipairs(lines) do
     local dir = line:match'memodir%s*=%s*"(.*)"'
     if dir then
-      return Path.expand(Path.new(dir))
+      return vim.fn.expand(dir)
     end
   end
   echo('cannot detect memodir', 'ErrorMsg')


### PR DESCRIPTION
`memodir`に環境変数が含まれていた場合、展開するように修正しました。
ただ、`${XDG_CONFIG_HOME}`のようにブラケットで囲まれている環境変数は`vim.fn.expand`が対応していないので出来ません。

> OK : memodir = "$XDG_CONFIG_HOME/memo/_posts"
> NG : memodir = "${XDG_CONFIG_HOME}/memo/_posts"