### PR TITLE
fix:update function that is deprecated in telescope

### DIFF
--- a/lua/telescope/_extensions/memo_builtin.lua
+++ b/lua/telescope/_extensions/memo_builtin.lua
@@ -1,6 +1,6 @@
 local conf = require'telescope.config'.values
 local entry_display = require'telescope.pickers.entry_display'
-local files = require'telescope.builtin.files'
+local builtin = require'telescope.builtin'
 local finders = require'telescope.finders'
 local from_entry = require'telescope.from_entry'
 local Path = require'plenary.path'
@@ -58,7 +58,7 @@ end
 
 local function set_default(opts)
   opts = opts or {}
-  opts.memo_bin = utils.get_default(opts.memo_bin, 'memo')
+  opts.memo_bin = vim.F.if_nil(opts.memo_bin, 'memo')
   opts.memo_dir = utils.get_lazy_default(opts.memo_dir, detect_memo_dir, opts.memo_bin)
   return opts
 end
@@ -89,19 +89,19 @@ end
 M.live_grep = function(opts)
   local memo_opts = set_default(opts)
   opts = vim.tbl_extend('force', {cwd = memo_opts.memo_dir}, opts or {})
-  files.live_grep(opts)
+  builtin.live_grep(opts)
 end
 
 M.grep_string = function(opts)
   local memo_opts = set_default(opts)
   opts = vim.tbl_extend('force', {cwd = memo_opts.memo_dir}, opts or {})
-  files.grep_string(opts)
+  builtin.grep_string(opts)
 end
 
 M.grep = function(opts)
   echo('DEPELECATED: use live_grep or grep_string instead of grep', 'WarningMsg')
   opts = set_default(opts)
-  files.live_grep{cwd = opts.memo_dir}
+  builtin.live_grep{cwd = opts.memo_dir}
 end
 
 return M


### PR DESCRIPTION
telescopoe.nvimでbuiltinの下で、exportされてた関数がdeprecatedになったりしたので、builtin直下の関数を参照するように修正
cf .nvim-telescope/telescope.nvim chore: remove deprecated functions / messages ([#2063](https://github.com/nvim-telescope/telescope.nvim/commit/5f253751916664caa15d9d6de8325e796db72686))